### PR TITLE
backport: Add support for has_octavia field over relation (#11)

### DIFF
--- a/docs/provides.md
+++ b/docs/provides.md
@@ -15,7 +15,7 @@ The flags that are set by the provides side of this interface are:
 <h1 id="provides.OpenStackIntegrationProvides">OpenStackIntegrationProvides</h1>
 
 ```python
-OpenStackIntegrationProvides(self, endpoint_name, relation_ids=None)
+OpenStackIntegrationProvides(endpoint_name, relation_ids=None)
 ```
 
 Example usage:
@@ -35,17 +35,17 @@ def handle_requests():
 <h2 id="provides.OpenStackIntegrationProvides.all_requests">all_requests</h2>
 
 
-A list of all of the `IntegrationRequests` that have been made.
+A list of all of the [`IntegrationRequests`](#provides.OpenStackIntegrationProvides.all_requests.IntegrationRequests) that have been made.
 
 <h2 id="provides.OpenStackIntegrationProvides.new_requests">new_requests</h2>
 
 
-A list of the new or updated `IntegrationRequests` that have been made.
+A list of the new or updated [`IntegrationRequests`](#provides.OpenStackIntegrationProvides.new_requests.IntegrationRequests) that have been made.
 
 <h2 id="provides.OpenStackIntegrationProvides.mark_completed">mark_completed</h2>
 
 ```python
-OpenStackIntegrationProvides.mark_completed(self)
+OpenStackIntegrationProvides.mark_completed()
 ```
 
 Mark all requests as completed and remove the `requests-pending` flag.
@@ -53,7 +53,7 @@ Mark all requests as completed and remove the `requests-pending` flag.
 <h1 id="provides.IntegrationRequest">IntegrationRequest</h1>
 
 ```python
-IntegrationRequest(self, unit)
+IntegrationRequest(unit)
 ```
 
 A request for integration from a single remote unit.
@@ -72,8 +72,37 @@ marked completed (if ever).
 <h2 id="provides.IntegrationRequest.set_credentials">set_credentials</h2>
 
 ```python
-IntegrationRequest.set_credentials(self, auth_url, region, username, password, user_domain_name, project_domain_name, project_name, endpoint_tls_ca)
+IntegrationRequest.set_credentials(auth_url,
+                                   region,
+                                   username,
+                                   password,
+                                   user_domain_name,
+                                   project_domain_name,
+                                   project_name,
+                                   endpoint_tls_ca,
+                                   version=None)
 ```
 
 Set the credentials for this request.
+
+<h2 id="provides.IntegrationRequest.set_lbaas_config">set_lbaas_config</h2>
+
+```python
+IntegrationRequest.set_lbaas_config(subnet_id,
+                                    floating_network_id,
+                                    lb_method,
+                                    manage_security_groups,
+                                    has_octavia=None)
+```
+
+Set the load-balancer-as-a-service config for this request.
+
+<h2 id="provides.IntegrationRequest.set_block_storage_config">set_block_storage_config</h2>
+
+```python
+IntegrationRequest.set_block_storage_config(bs_version, trust_device_path,
+                                            ignore_volume_az)
+```
+
+Set the block storage config for this request.
 

--- a/docs/requires.md
+++ b/docs/requires.md
@@ -19,10 +19,14 @@ The flags that are set by the requires side of this interface are:
   running.  This flag is automatically removed if new integration features are
   requested.  It should not be removed by the charm.
 
+* **`endpoint.{endpoint_name}.ready.changed`** This flag is set if the data
+  changes after the ready flag was set.  This flag should be removed by the
+  charm once handled.
+
 <h1 id="requires.OpenStackIntegrationRequires">OpenStackIntegrationRequires</h1>
 
 ```python
-OpenStackIntegrationRequires(self, endpoint_name, relation_ids=None)
+OpenStackIntegrationRequires(endpoint_name, relation_ids=None)
 ```
 
 Interface to request integration access.
@@ -51,6 +55,12 @@ def openstack_integration_ready():
 
 The authentication endpoint URL.
 
+<h2 id="requires.OpenStackIntegrationRequires.bs_version">bs_version</h2>
+
+
+What block storage API version to use, `auto` if autodetection is
+desired, or `None` to use the default.
+
 <h2 id="requires.OpenStackIntegrationRequires.endpoint_tls_ca">endpoint_tls_ca</h2>
 
 
@@ -61,6 +71,27 @@ or None.
 
 
 Optional floating network ID, or None.
+
+<h2 id="requires.OpenStackIntegrationRequires.has_octavia">has_octavia</h2>
+
+
+Whether the underlying OpenStack supports Octavia instead of
+Neutron-based LBaaS.
+
+Will either be True, False, or None if it could not be determined for
+some reason (typically due to connecting to an older integrator charm).
+
+<h2 id="requires.OpenStackIntegrationRequires.ignore_volume_az">ignore_volume_az</h2>
+
+
+Whether to ignore availability zones when attaching Cinder volumes.
+
+Will be `True`, `False`, or `None`.
+
+<h2 id="requires.OpenStackIntegrationRequires.is_changed">is_changed</h2>
+
+
+Whether or not the request for this instance has changed.
 
 <h2 id="requires.OpenStackIntegrationRequires.is_ready">is_ready</h2>
 
@@ -105,6 +136,13 @@ The region name.
 
 Optional subnet ID to work in, or None.
 
+<h2 id="requires.OpenStackIntegrationRequires.trust_device_path">trust_device_path</h2>
+
+
+Whether to trust the block device name provided by Ceph.
+
+Will be `True`, `False`, or `None`.
+
 <h2 id="requires.OpenStackIntegrationRequires.user_domain_name">user_domain_name</h2>
 
 
@@ -114,4 +152,9 @@ The user domain name.
 
 
 The username.
+
+<h2 id="requires.OpenStackIntegrationRequires.version">version</h2>
+
+
+Optional version number for the APIs or None.
 

--- a/provides.py
+++ b/provides.py
@@ -97,7 +97,8 @@ class IntegrationRequest:
                         user_domain_name,
                         project_domain_name,
                         project_name,
-                        endpoint_tls_ca):
+                        endpoint_tls_ca,
+                        version=None):
         """
         Set the credentials for this request.
         """
@@ -110,13 +111,15 @@ class IntegrationRequest:
             'project_domain_name': project_domain_name,
             'project_name': project_name,
             'endpoint_tls_ca': endpoint_tls_ca,
+            'version': version,
         })
 
     def set_lbaas_config(self,
                          subnet_id,
                          floating_network_id,
                          lb_method,
-                         manage_security_groups):
+                         manage_security_groups,
+                         has_octavia=None):
         """
         Set the load-balancer-as-a-service config for this request.
         """
@@ -125,6 +128,7 @@ class IntegrationRequest:
             'floating_network_id': floating_network_id,
             'lb_method': lb_method,
             'manage_security_groups': manage_security_groups,
+            'has_octavia': has_octavia,
         })
 
     def set_block_storage_config(self,

--- a/requires.py
+++ b/requires.py
@@ -179,6 +179,13 @@ class OpenStackIntegrationRequires(Endpoint):
         return self._received['endpoint_tls_ca'] or None
 
     @property
+    def version(self):
+        """
+        Optional version number for the APIs or None.
+        """
+        return self._received['version'] or None
+
+    @property
     def subnet_id(self):
         """
         Optional subnet ID to work in, or None.
@@ -234,3 +241,14 @@ class OpenStackIntegrationRequires(Endpoint):
         Will be `True`, `False`, or `None`.
         """
         return self._received['ignore_volume_az']
+
+    @property
+    def has_octavia(self):
+        """
+        Whether the underlying OpenStack supports Octavia instead of
+        Neutron-based LBaaS.
+
+        Will either be True, False, or None if it could not be determined for
+        some reason (typically due to connecting to an older integrator charm).
+        """
+        return self._received['has_octavia']


### PR DESCRIPTION
Backport juju-solutions#11 to stable.

* Add support for has_octavia field over relation

Add support for the integrator charm to detect and communicate whether
Octavia is actually available.

* Add version to interface